### PR TITLE
feat : 권한 체크 aop 기능 구현

### DIFF
--- a/src/main/java/com/server/nodak/exception/common/AuthorizationException.java
+++ b/src/main/java/com/server/nodak/exception/common/AuthorizationException.java
@@ -1,0 +1,15 @@
+package com.server.nodak.exception.common;
+
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+public class AuthorizationException extends BaseException {
+    public AuthorizationException() {
+        super(UNAUTHORIZED.value(), "접근 권한이 없습니다.");
+    }
+
+    public AuthorizationException(String message) {
+        super(UNAUTHORIZED.value(), message);
+    }
+}

--- a/src/main/java/com/server/nodak/security/aop/AuthorizationAop.java
+++ b/src/main/java/com/server/nodak/security/aop/AuthorizationAop.java
@@ -1,0 +1,53 @@
+package com.server.nodak.security.aop;
+
+import com.server.nodak.domain.user.domain.UserRole;
+import com.server.nodak.exception.common.AuthorizationException;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+
+@Aspect
+@Component
+public class AuthorizationAop {
+
+    @Before("@annotation(com.server.nodak.security.aop.AuthorizationRequired)")
+    public void checkAccessLevel(JoinPoint joinPoint) {
+        AuthorizationRequired annotation = getAnnotation(joinPoint);
+
+        Collection<? extends GrantedAuthority> possibleAuthority = roleToAuthority(annotation.value());
+
+        if (!hasAuthority(possibleAuthority)) {
+            throw new AuthorizationException();
+        }
+    }
+
+    private boolean hasAuthority(Collection<? extends GrantedAuthority> possibleAuthority) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.getAuthorities()
+                .stream().anyMatch(possibleAuthority::contains);
+    }
+
+    private AuthorizationRequired getAnnotation(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        return method.getAnnotation(AuthorizationRequired.class);
+    }
+
+    private Collection<? extends GrantedAuthority> roleToAuthority(UserRole[] required) {
+        return Arrays.stream(required)
+                .map(Enum::name)
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/server/nodak/security/aop/AuthorizationRequired.java
+++ b/src/main/java/com/server/nodak/security/aop/AuthorizationRequired.java
@@ -1,0 +1,15 @@
+package com.server.nodak.security.aop;
+
+import com.server.nodak.domain.user.domain.UserRole;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface AuthorizationRequired {
+    UserRole[] value();
+}

--- a/src/test/java/com/server/nodak/security/aop/AuthorizationAopTest.java
+++ b/src/test/java/com/server/nodak/security/aop/AuthorizationAopTest.java
@@ -1,0 +1,102 @@
+package com.server.nodak.security.aop;
+
+import com.server.nodak.domain.user.domain.UserRole;
+import com.server.nodak.exception.common.AuthorizationException;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.server.nodak.domain.user.domain.UserRole.*;
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import(AuthorizationAopTest.AnnotationAopTester.class)
+class AuthorizationAopTest {
+    @Autowired
+    AuthorizationAop authorizationAop;
+    @Autowired
+    AnnotationAopTester annotationAopTester;
+
+    @ParameterizedTest
+    @EnumSource(UserRole.class)
+    @DisplayName("접근 권한이 없는 컨트롤러에 접근 시 예외가 반한된다.")
+    void notHaveAccessRight(UserRole currentRole) {
+        // given
+        setAuthority(currentRole);
+
+        // when
+
+        // then
+        if (currentRole != MANAGER) {
+            assertThatThrownBy(() -> annotationAopTester.managerRoleFunc())
+                    .isInstanceOf(AuthorizationException.class);
+        }
+
+        if (currentRole != GENERAL) {
+            assertThatThrownBy(() -> annotationAopTester.generalRoleFunc())
+                    .isInstanceOf(AuthorizationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(UserRole.class)
+    @DisplayName("접근 권한이 없는 컨트롤러에 접근 시 예외가 반한된다.")
+    void hasAccessRight(UserRole currentRole) {
+        // given
+        setAuthority(currentRole);
+
+        // when
+
+        // then
+        if (currentRole == MANAGER) {
+            assertTrue(annotationAopTester.managerRoleFunc());
+        }
+
+        if (currentRole == GENERAL) {
+            assertTrue(annotationAopTester.generalRoleFunc());
+        }
+    }
+
+    private void setAuthority(UserRole role) {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                null, null, singleton(new SimpleGrantedAuthority(role.name()))
+        ));
+    }
+
+    @Component
+    static class AnnotationAopTester {
+
+        @AuthorizationRequired(GENERAL)
+        public boolean generalRoleFunc() {
+            return true;
+        }
+
+        @AuthorizationRequired(MANAGER)
+        public boolean managerRoleFunc() {
+            return true;
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Description ✍️
- 권한 체크용 aop 기능 구현
- Controller 단에 annotation을 통한 권한 체크용 aop 기능 입니다.
- 해당 [pr](https://github.com/nodak-v2/Nodak-Server/pull/25)을 base로 하여 기능 구현했습니다. 해당 [pr](https://github.com/nodak-v2/Nodak-Server/pull/25) 먼저 리뷰 후, 봐주시면 감사하겠습니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?