### PR TITLE
perform : VoteHistory 테이블 인덱스 최적화

### DIFF
--- a/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
+++ b/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
@@ -18,7 +18,7 @@ import com.server.nodak.domain.user.repository.UserJpaRepository;
 import com.server.nodak.domain.vote.domain.Vote;
 import com.server.nodak.domain.vote.domain.VoteHistory;
 import com.server.nodak.domain.vote.domain.VoteOption;
-import com.server.nodak.domain.vote.repository.VoteHistoryRepository;
+import com.server.nodak.domain.vote.repository.votehistory.VoteHistoryRepository;
 import com.server.nodak.global.config.QueryDslConfig;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
+++ b/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
@@ -40,7 +40,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.Rollback;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -50,7 +49,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("perform")
+//@ActiveProfiles("perform")
 @Import({QueryDslConfig.class})
 @DisplayName("VoteHistory 인덱스 최적화 테스트")
 @Slf4j

--- a/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
+++ b/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
@@ -1,0 +1,219 @@
+package com.server.nodak.domain.vote.perform;
+
+import static com.server.nodak.domain.vote.domain.QVoteHistory.voteHistory;
+import static com.server.nodak.domain.vote.domain.QVoteOption.voteOption;
+import static com.server.nodak.domain.vote.utils.Utils.createPost;
+import static com.server.nodak.domain.vote.utils.Utils.createVote;
+import static com.server.nodak.domain.vote.utils.Utils.createVoteHistory;
+import static com.server.nodak.domain.vote.utils.Utils.createVoteOption;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.server.nodak.domain.post.domain.Category;
+import com.server.nodak.domain.post.domain.Post;
+import com.server.nodak.domain.post.repository.CategoryRepository;
+import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.domain.UserProvider;
+import com.server.nodak.domain.user.repository.UserJpaRepository;
+import com.server.nodak.domain.vote.domain.Vote;
+import com.server.nodak.domain.vote.domain.VoteHistory;
+import com.server.nodak.domain.vote.domain.VoteOption;
+import com.server.nodak.domain.vote.repository.VoteHistoryRepository;
+import com.server.nodak.global.config.QueryDslConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("perform")
+@Import({QueryDslConfig.class})
+@DisplayName("Post 검색 성능 테스트")
+@Slf4j
+@Rollback(value = false)
+@Transactional
+public class VoteHistoryIndexOptimizeTest {
+
+    Random rnd = new Random();
+
+    @Autowired
+    JPAQueryFactory queryFactory;
+
+    @Autowired
+    UserJpaRepository userRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    VoteHistoryRepository voteHistoryRepository;
+
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    @Test
+    @Disabled
+    @DisplayName("existsHistoryByVoteId 비용을 계산합니다.")
+    public void existsHistoryByTest() {
+        Long cost = Stream.generate(() -> {
+                    Long userId = rnd.nextLong(1, 1000);
+                    Long voteId = rnd.nextLong(1, 40000);
+
+                    JPAQuery<Integer> query = queryFactory.selectOne()
+                            .from(voteOption)
+                            .innerJoin(voteHistory)
+                            .on(voteOption.id.eq(voteHistory.voteOption.id))
+                            .where(
+                                    voteOption.vote.id.eq(voteId),
+                                    voteHistory.user.id.eq(userId)
+                            );
+                    return fetchFirstQuery(query);
+                })
+                .limit(10)
+                .reduce(0L, Long::sum);
+
+        log.info("existsHistoryByVoteId time cost : {}", cost / 10);
+    }
+
+    @Test
+    @Disabled
+    @DisplayName("findVoteIdAndUserId 비용을 계산합니다.")
+    public void findVoteIdAndUserId() {
+        Long cost = Stream.generate(() -> {
+                    Long userId = rnd.nextLong(1, 1000);
+                    Long voteId = rnd.nextLong(1, 40000);
+
+                    JPAQuery<VoteHistory> query = queryFactory
+                            .selectFrom(voteHistory)
+                            .where(voteHistory.user.id.eq(userId).and(voteHistory.voteOption.vote.id.eq(voteId))
+                            );
+                    return fetchFirstQuery(query);
+                })
+                .limit(10)
+                .reduce(0L, Long::sum);
+
+        log.info("findVoteIdAndUserId time cost : {}", cost / 10);
+    }
+
+    private long fetchFirstQuery(JPAQuery<?> query) {
+        long startTime = System.currentTimeMillis();
+        query.fetchFirst();
+        long endTime = System.currentTimeMillis();
+        return endTime - startTime;
+    }
+
+    @Test
+    @Disabled
+    public void createUserAndCategoryTestData() {
+        saveUser(1000);
+        saveCategory();
+    }
+
+    @Test
+    @Transactional
+    @Disabled
+    public void createPostTestData() {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+        List<? extends Future<?>> futures = Stream.generate(
+                () -> executorService.submit(() -> {
+                    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+                    transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+                    transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+                        @Override
+                        protected void doInTransactionWithoutResult(TransactionStatus status) {
+                            savePost(2000, 3, 10);
+                        }
+                    });
+                })
+        ).limit(20).toList();
+
+        futures.forEach(future -> {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+
+    public void saveUser(int idx) {
+        userRepository.saveAll(createUsers(idx, UserProvider.KAKAO));
+    }
+
+    public void saveCategory() {
+        List.of("운동", "연애", "개발", "요리", "잡담").stream().forEach(category -> {
+            categoryRepository.save(new Category(category));
+        });
+    }
+
+    public void savePost(int postIdx, int voteOptionIdx, int voteHistoryIdx) {
+        List<VoteOption> voteOptions = new ArrayList<>();
+        List<VoteHistory> voteHistories = new ArrayList<>();
+
+        IntStream.rangeClosed(1, postIdx).forEach(e -> {
+            User user = userRepository.findById(rnd.nextLong(1, 200)).get();
+            Category category = categoryRepository.findById(rnd.nextLong(1, 4)).get();
+            Post post = createPost(user, randomUUID(1, 10), randomUUID(1, 10), category);
+            Vote vote = createVote(randomUUID(1, 10), post);
+            voteOptions.addAll(createVoteOptions(vote, voteOptionIdx));
+        });
+
+        voteOptions.stream().forEach(voteOption -> {
+            List<VoteHistory> list = IntStream.rangeClosed(1, voteHistoryIdx).mapToObj(e -> {
+                User user = userRepository.findById(rnd.nextLong(1, 200)).get();
+                return createVoteHistory(user, voteOption);
+            }).toList();
+            voteHistories.addAll(list);
+        });
+
+        voteHistoryRepository.saveAll(voteHistories);
+    }
+
+    private List<User> createUsers(int idx, UserProvider provider) {
+        return IntStream.rangeClosed(1, idx).mapToObj(e ->
+                User.createUser(
+                        randomUUID(1, 10),
+                        randomUUID(1, 10),
+                        randomUUID(1, 10),
+                        provider)
+        ).toList();
+    }
+
+    private List<VoteOption> createVoteOptions(Vote vote, int size) {
+        return IntStream.rangeClosed(1, size).mapToObj(e ->
+                createVoteOption(vote, e, String.format("VoteOption_content_%d", e))
+        ).collect(Collectors.toList());
+    }
+
+    public String randomUUID(int start, int end) {
+        return UUID.randomUUID().toString().substring(start, end);
+    }
+}

--- a/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
+++ b/src/test/java/com/server/nodak/domain/vote/perform/VoteHistoryIndexOptimizeTest.java
@@ -52,7 +52,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("perform")
 @Import({QueryDslConfig.class})
-@DisplayName("Post 검색 성능 테스트")
+@DisplayName("VoteHistory 인덱스 최적화 테스트")
 @Slf4j
 @Rollback(value = false)
 @Transactional

--- a/src/test/resources/application-perform.yaml
+++ b/src/test/resources/application-perform.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/nodak_test?rewriteBatchedStatements=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: 1234
+    hikari:
+      connection-timeout: 500000
+      maximum-pool-size: 10
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## Description ✍️
VoteHistory 테이블은 N:N 관계를 해소하기 위한 관계 테이블입니다. 

서비스 중심으로 보았을 때, Votehistory 테이블은 조인이 빈번하게 발생합니다. 하지만, PK값으로 조회하는 경우는 존재하지 않으며, vote_option_id로 조회하는 빈도가 낮았고, user_id로 조회하는 빈도가 높다는 것을 확인했습니다. 

따라서, 조회 성능을 향상 시키기 위해 user_id 필드에 index를 생성해보았습니다.

* 멀티 스레드 환경에서  테스트 데이터 생성  
  * User 데이터 : 1,000건
  * Post, Vote 데이터 : 40,000건
  * VoteOption 데이터 : 120,000건
  * VoteHistory 데이터 : 1,200,000건
  * 대량의 데이터 삽입을 위해 application-perform.yaml을 생성했습니다.
  * 대량의 데이터 삽입과 대량의 데이터를 통해 테스트가 가능한 성능 테스트 코드는 빌드 테스트에 포함되지 않도록 `@Disable`어노테이션을 추가했습니다.
* 10회 평균 시간 비용 테스트 코드 작성
  * existsHistoryByVoteId  **339ms -> 44ms 약 87% 성능 향상**
  * findByVoteIdAndUserId **445ms -> 34ms 약 92% 성능 향상**
* WorkBench 실행 계획 테스트
  * existsHistoryByVoteId  **251993.61 -> 4266.50 query_cost 향상** 
  * findByVoteIdAndUserId **251993.61 -> 0.70 query_cost 향상**

  
## Screen Shot 📷
* existsHistoryByVoteId
<img width="730" alt="image" src="https://github.com/nodak-v2/Nodak-Server/assets/85385921/469b8c4c-2a80-49e3-bd3e-a3bf9fd3f1b1">

* findVoteIdAndUserId
<img width="731" alt="image" src="https://github.com/nodak-v2/Nodak-Server/assets/85385921/e2a485e8-01ed-4b7e-8fb5-c47497bb694b">

* existsHistoryByVoteId
<img width="311" alt="image" src="https://github.com/nodak-v2/Nodak-Server/assets/85385921/fd613fa9-84cb-45d7-a2ab-9ec2455c2655">

* findVoteIdAndUserId
<img width="297" alt="image" src="https://github.com/nodak-v2/Nodak-Server/assets/85385921/9743a2c4-4594-4854-886f-d6d567fb8b8d">


## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?

