### PR TITLE
feat : 유저 상태 도메인 및 Repository 구현

### DIFF
--- a/src/main/java/com/server/nodak/domain/userstatus/domain/UserStatus.java
+++ b/src/main/java/com/server/nodak/domain/userstatus/domain/UserStatus.java
@@ -1,0 +1,38 @@
+package com.server.nodak.domain.userstatus.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserStatus {
+    private Long userId;
+
+    private boolean isActivate;
+
+    private String nickname;
+
+    private LocalDateTime lastConnected;
+
+    public static UserStatus createUserStatus(Long userId, String nickname, boolean isActivate) {
+        UserStatus userStatus = new UserStatus();
+        userStatus.userId = userId;
+        userStatus.isActivate = isActivate;
+        userStatus.nickname = nickname;
+
+        if (isActivate) {
+            userStatus.lastConnected = LocalDateTime.now();
+        }
+
+        return userStatus;
+    }
+
+    public void updateActivate(boolean isActivate) {
+        this.isActivate = isActivate;
+
+        if (isActivate) {
+            lastConnected = LocalDateTime.now();
+        }
+    }
+
+}

--- a/src/main/java/com/server/nodak/domain/userstatus/dto/UserStatusResponse.java
+++ b/src/main/java/com/server/nodak/domain/userstatus/dto/UserStatusResponse.java
@@ -1,0 +1,16 @@
+package com.server.nodak.domain.userstatus.dto;
+
+import com.server.nodak.domain.userstatus.domain.UserStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserStatusResponse {
+    private Long userId;
+    private String nickname;
+    private boolean isActivate;
+
+    public static UserStatusResponse of(UserStatus userStatus) {
+        return new UserStatusResponse(userStatus.getUserId(), userStatus.getNickname(), userStatus.isActivate());
+    }
+}

--- a/src/main/java/com/server/nodak/domain/userstatus/repository/InMemoryUserStatusRepository.java
+++ b/src/main/java/com/server/nodak/domain/userstatus/repository/InMemoryUserStatusRepository.java
@@ -1,0 +1,30 @@
+package com.server.nodak.domain.userstatus.repository;
+
+import com.server.nodak.domain.userstatus.domain.UserStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryUserStatusRepository implements UserStatusRepository {
+    private final Map<Long, UserStatus> inMemoryRepository = new ConcurrentHashMap<>();
+
+    @Override
+    public UserStatus put(UserStatus userStatus) {
+        return inMemoryRepository.put(userStatus.getUserId(), userStatus);
+    }
+
+    @Override
+    public Optional<UserStatus> findByUserId(Long userId) {
+        return Optional.ofNullable(inMemoryRepository.get(userId));
+    }
+
+    @Override
+    public List<UserStatus> getAll() {
+        return inMemoryRepository.values().stream()
+                .toList();
+    }
+}

--- a/src/main/java/com/server/nodak/domain/userstatus/repository/UserStatusRepository.java
+++ b/src/main/java/com/server/nodak/domain/userstatus/repository/UserStatusRepository.java
@@ -1,0 +1,15 @@
+package com.server.nodak.domain.userstatus.repository;
+
+import com.server.nodak.domain.userstatus.domain.UserStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserStatusRepository {
+
+    UserStatus put(UserStatus userStatus);
+
+    Optional<UserStatus> findByUserId(Long userId);
+
+    List<UserStatus> getAll();
+}

--- a/src/main/java/com/server/nodak/domain/userstatus/service/UserStatusService.java
+++ b/src/main/java/com/server/nodak/domain/userstatus/service/UserStatusService.java
@@ -1,0 +1,50 @@
+package com.server.nodak.domain.userstatus.service;
+
+import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.domain.UserRole;
+import com.server.nodak.domain.user.repository.UserRepository;
+import com.server.nodak.domain.userstatus.domain.UserStatus;
+import com.server.nodak.domain.userstatus.dto.UserStatusResponse;
+import com.server.nodak.domain.userstatus.repository.UserStatusRepository;
+import com.server.nodak.exception.common.DataNotFoundException;
+import com.server.nodak.security.SecurityUtils;
+import com.server.nodak.security.aop.AuthorizationRequired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static com.server.nodak.domain.userstatus.domain.UserStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserStatusService {
+    private final UserStatusRepository userStatusRepository;
+    private final UserRepository userRepository;
+
+    @AuthorizationRequired(UserRole.GENERAL)
+    public void updateHeartBeat(Long userId, boolean isActivate) {
+        String nickname = getNickname(userId);
+        
+        if (nickname == null) {
+            throw new DataNotFoundException();
+        }
+
+        UserStatus userStatus = createUserStatus(userId, nickname, isActivate);
+        userStatusRepository.put(userStatus);
+    }
+
+    public List<UserStatusResponse> getAllUserStatusResponse() {
+        return userStatusRepository.getAll().stream()
+                .sorted(Comparator.comparing(UserStatus::getLastConnected).reversed())
+                .map(UserStatusResponse::of)
+                .toList();
+    }
+
+    private String getNickname(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Description ✍️
- 인메모리 유저 상태 DB 임시 구현 (-> 추후, DynamoDB로 변경 예정)
- 유저 상태 엔티티 구현

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
