### PR TITLE
refactor :  Post 리스트 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/server/nodak/domain/post/domain/Post.java
+++ b/src/main/java/com/server/nodak/domain/post/domain/Post.java
@@ -46,7 +46,7 @@ public class Post extends BaseEntity {
     @ColumnDefault("false")
     private boolean isDeleted;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 

--- a/src/main/java/com/server/nodak/domain/post/dto/PostSearchResponse.java
+++ b/src/main/java/com/server/nodak/domain/post/dto/PostSearchResponse.java
@@ -12,19 +12,22 @@ public class PostSearchResponse {
     private Long postId;
     private Long voteId;
     private String title;
-    private Long totalCount;
+    private Integer commentCount;
+    private Integer likeCount;
+    private Long voterCount;
     private String author;
     private String profileImageUrl;
     private String postImageUrl;
 
     @QueryProjection
-    public PostSearchResponse(Long postId, Long voteId, String title, Long totalCount, String author,
-                              String profileImageUrl,
-                              String postImageUrl) {
+    public PostSearchResponse(Long postId, Long voteId, String title, Integer commentCount, Integer likeCount,
+                              Long voterCount, String author, String profileImageUrl, String postImageUrl) {
         this.postId = postId;
         this.voteId = voteId;
         this.title = title;
-        this.totalCount = totalCount;
+        this.commentCount = commentCount;
+        this.likeCount = likeCount;
+        this.voterCount = voterCount;
         this.author = author;
         this.profileImageUrl = profileImageUrl;
         this.postImageUrl = postImageUrl;

--- a/src/main/java/com/server/nodak/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/server/nodak/domain/post/repository/PostRepositoryImpl.java
@@ -64,6 +64,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                 post.id,
                                 post.vote.id,
                                 post.title,
+                                post.comments.size(),
+                                post.starPosts.size(),
                                 JPAExpressions
                                         .select(voteHistory.count())
                                         .from(voteHistory)

--- a/src/test/java/com/server/nodak/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/server/nodak/domain/post/service/PostServiceTest.java
@@ -205,7 +205,7 @@ class PostServiceTest {
                 .mapToObj(e -> PostSearchResponse.builder().postId(e)
                         .postImageUrl(String.format("http://postImage%d.com", e))
                         .author(String.format("작성자%d", e))
-                        .profileImageUrl(String.format("http://profileImage%d.com", e)).totalCount(10L).build())
+                        .profileImageUrl(String.format("http://profileImage%d.com", e)).voterCount(10L).build())
                 .toList();
     }
 


### PR DESCRIPTION
## Description ✍️
- User : Post Cascade Persist 속성 추가
  - Post 데이터는 User가 항상 존재해야 의미가 있습니다. 
  Persist 속성을 추가하면, Post 저장 시 이미 User 객체를 한번 persist하기 때문에 `detached persist` 이슈를 만나게 됩니다. 
  - 이러한 문제가 발생하는 이유는 JPA 영속성 컨텍스트가 트랜잭션 단위이기 때문입니다. 
  따라서, 같은 트랜잭션으로 묶으면 `detached persist` 이슈를 해결할 수 있습니다.
  - 기존의 구현 코드에서 문제가 없었는데 구현한 이유는 User는 모든 테이블(게시글, 투표, 팔로우, 댓글 등등) 저장 시 User를 저장하는 코드가 중복되어서, persist 속성을 적용해보았습니다.
  Service 계층에서  Post를 저장하는 코드를 살펴보면 하나의 트랜잭션으로 묶여있어야하기 때문에 구현코드에는 문제가 되지 않을 것 같아서 추가했습니다.
  
- Post 리스트 조회 시, 응답 필드를 변경합니다.
  - totalCount(투표 참여 수)를 �voterCount 필드로 변경합니다.
  - commentCount(댓글 수), likeCount(좋아요 수) 필드를 추가합니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [x] 모든 리뷰어의 승인을 받았나요?


