### PR TITLE
fix : cookie samesite 설정 해제

### DIFF
--- a/src/main/java/com/server/nodak/utils/HttpServletUtils.java
+++ b/src/main/java/com/server/nodak/utils/HttpServletUtils.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -24,11 +25,15 @@ public class HttpServletUtils {
     }
 
     public void addCookie(HttpServletResponse response, String name, String value, int seconds) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-        cookie.setMaxAge(seconds);
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(seconds)
+                .build();
+
+        response.addHeader(name, cookie.toString());
     }
 
     public void removeCookie(HttpServletRequest request, HttpServletResponse response, String name) {

--- a/src/test/java/com/server/nodak/utils/HttpServletUtilsTest.java
+++ b/src/test/java/com/server/nodak/utils/HttpServletUtilsTest.java
@@ -82,7 +82,7 @@ class HttpServletUtilsTest {
 
         // then
         verify(mockResponse, times(1))
-                .addCookie(any(Cookie.class));
+                .addHeader(name, anyString());
     }
 
     @Test


### PR DESCRIPTION
## Description ✍️
- 프론트(localhost:3000)에서 쿠키 조회 안되는 문제 해결
  - 쿠키 samesite 설정 해제

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
