### PR TITLE
feat : 잔디밭 기능 구현

### DIFF
--- a/src/main/java/com/server/nodak/NodakApplication.java
+++ b/src/main/java/com/server/nodak/NodakApplication.java
@@ -3,8 +3,10 @@ package com.server.nodak;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class NodakApplication {
 

--- a/src/main/java/com/server/nodak/domain/comment/service/CommentService.java
+++ b/src/main/java/com/server/nodak/domain/comment/service/CommentService.java
@@ -29,7 +29,7 @@ public class CommentService {
     private final UserHistoryRepository userHistoryRepository;
 
     @Transactional
-    @IncreaseUserHistory
+    @IncreaseUserHistory(incrementValue = 2)
     public void createComment(long postId, long userId, CreateCommentRequest commentRequest) {
         Post post = findPost(postId);
         User user = findUser(userId);

--- a/src/main/java/com/server/nodak/domain/comment/service/CommentService.java
+++ b/src/main/java/com/server/nodak/domain/comment/service/CommentService.java
@@ -8,15 +8,16 @@ import com.server.nodak.domain.comment.repository.CommentRepository;
 import com.server.nodak.domain.post.domain.Post;
 import com.server.nodak.domain.post.repository.PostRepository;
 import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.repository.UserHistoryRepository;
 import com.server.nodak.domain.user.repository.UserRepository;
 import com.server.nodak.exception.common.BadRequestException;
 import com.server.nodak.exception.common.DataNotFoundException;
+import com.server.nodak.security.aop.IncreaseUserHistory;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +26,10 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final UserHistoryRepository userHistoryRepository;
 
     @Transactional
+    @IncreaseUserHistory
     public void createComment(long postId, long userId, CreateCommentRequest commentRequest) {
         Post post = findPost(postId);
         User user = findUser(userId);

--- a/src/main/java/com/server/nodak/domain/post/service/PostService.java
+++ b/src/main/java/com/server/nodak/domain/post/service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
     private final UserHistoryRepository userHistoryRepository;
 
     @Transactional
-    @IncreaseUserHistory
+    @IncreaseUserHistory(incrementValue = 2)
     public void savePost(Long userId, PostRequest request) {
         User user = findUserById(userId);
         Category category = findCategoryByTitle(request.getChannel());

--- a/src/main/java/com/server/nodak/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/nodak/domain/user/controller/UserController.java
@@ -1,18 +1,26 @@
 package com.server.nodak.domain.user.controller;
 
+import static com.server.nodak.global.common.response.ApiResponse.success;
+import static org.springframework.http.ResponseEntity.ok;
+
 import com.server.nodak.domain.user.domain.UserRole;
 import com.server.nodak.domain.user.dto.CurrentUserInfoResponse;
+import com.server.nodak.domain.user.dto.UserHistoryListResponse;
 import com.server.nodak.domain.user.dto.UserInfoResponse;
 import com.server.nodak.domain.user.dto.UserUpdateDTO;
 import com.server.nodak.domain.user.service.UserService;
 import com.server.nodak.global.common.response.ApiResponse;
 import com.server.nodak.security.aop.AuthorizationRequired;
+import java.security.Principal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import static com.server.nodak.global.common.response.ApiResponse.*;
-import static org.springframework.http.ResponseEntity.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/user")
@@ -37,4 +45,13 @@ public class UserController {
         userService.updateUserInfo(userUpdateDTO);
         return ok(success());
     }
+
+    @GetMapping("/history")
+    @AuthorizationRequired({UserRole.GENERAL, UserRole.MANAGER})
+    public ResponseEntity<ApiResponse<List<UserHistoryListResponse>>> getUserHistory(Principal principal) {
+        long userId = Long.parseLong(principal.getName());
+
+        return ResponseEntity.ok(success(userService.getUserHistory(userId)));
+    }
+
 }

--- a/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
+++ b/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
@@ -1,0 +1,63 @@
+package com.server.nodak.domain.user.domain;
+
+import com.server.nodak.domain.model.BaseEntity;
+import com.server.nodak.domain.user.dto.UserHistoryListResponse;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class UserHistory extends BaseEntity {
+
+    private Long count;
+
+    private LocalDateTime actionDateTime;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @Builder
+    public UserHistory(Long count, User user, LocalDateTime actionDateTime) {
+        this.count = count;
+        setUser(user);
+        this.actionDateTime = actionDateTime;
+    }
+
+    private void setUser(User user) {
+        this.user = user;
+    }
+
+    public UserHistoryListResponse toListResponse() {
+        return UserHistoryListResponse.builder()
+                .date(this.actionDateTime.toLocalDate())
+                .level(checkLevel())
+                .build();
+    }
+
+    private Long checkLevel() {
+        if (this.count > 10) {
+            return 3L;
+        } else if (this.count > 5) {
+            return 2L;
+        }
+        return 1L;
+    }
+
+    public void increaseCount() {
+        this.count++;
+    }
+}

--- a/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
+++ b/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
@@ -49,9 +49,9 @@ public class UserHistory extends BaseEntity {
     }
 
     private Long checkLevel() {
-        if (this.count > 10) {
+        if (this.count >= 6) {
             return 3L;
-        } else if (this.count > 5) {
+        } else if (this.count >= 3) {
             return 2L;
         }
         return 1L;

--- a/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
+++ b/src/main/java/com/server/nodak/domain/user/domain/UserHistory.java
@@ -57,7 +57,7 @@ public class UserHistory extends BaseEntity {
         return 1L;
     }
 
-    public void increaseCount() {
-        this.count++;
+    public void increaseCount(int incrementValue) {
+        this.count = count + incrementValue;
     }
 }

--- a/src/main/java/com/server/nodak/domain/user/dto/UserHistoryListResponse.java
+++ b/src/main/java/com/server/nodak/domain/user/dto/UserHistoryListResponse.java
@@ -1,0 +1,18 @@
+package com.server.nodak.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class UserHistoryListResponse {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private Long level;
+}

--- a/src/main/java/com/server/nodak/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/server/nodak/domain/user/dto/UserInfoResponse.java
@@ -1,13 +1,13 @@
 package com.server.nodak.domain.user.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 import com.server.nodak.domain.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -24,6 +24,7 @@ public class UserInfoResponse {
     private LocalDateTime updatedAt;
     private int followerCount;
     private int followeeCount;
+    private List<UserHistoryListResponse> userHistory;
 
     protected UserInfoResponse(User user, int followerCount, int followeeCount) {
         this.userId = user.getId();
@@ -37,8 +38,23 @@ public class UserInfoResponse {
         this.followeeCount = followeeCount;
     }
 
+    protected UserInfoResponse(User user, int followerCount, int followeeCount,
+                               List<UserHistoryListResponse> userHistory) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.profileImageUrl = user.getProfileImageUrl();
+        this.introduction = user.getDescription();
+        this.createdAt = user.getCreatedAt();
+        this.updatedAt = user.getUpdatedAt();
+        this.followerCount = followerCount;
+        this.followeeCount = followeeCount;
+        this.userHistory = userHistory;
+    }
+
     @QueryProjection
-    public UserInfoResponse(Long userId, String email, String nickname, String profileImageUrl, String introduction, LocalDateTime createdAt, LocalDateTime updatedAt, int followerCount, int followeeCount) {
+    public UserInfoResponse(Long userId, String email, String nickname, String profileImageUrl, String introduction,
+                            LocalDateTime createdAt, LocalDateTime updatedAt, int followerCount, int followeeCount) {
         this.userId = userId;
         this.email = email;
         this.nickname = nickname;
@@ -52,5 +68,10 @@ public class UserInfoResponse {
 
     public static UserInfoResponse of(User user, int followerCount, int followeeCount) {
         return new UserInfoResponse(user, followerCount, followeeCount);
+    }
+
+    public static UserInfoResponse of(User user, int followerCount, int followeeCount,
+                                      List<UserHistoryListResponse> userHistory) {
+        return new UserInfoResponse(user, followerCount, followeeCount, userHistory);
     }
 }

--- a/src/main/java/com/server/nodak/domain/user/repository/UserHistoryRepository.java
+++ b/src/main/java/com/server/nodak/domain/user/repository/UserHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.server.nodak.domain.user.repository;
+
+import com.server.nodak.domain.user.domain.UserHistory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserHistoryRepository extends JpaRepository<UserHistory, Long> {
+    Optional<UserHistory> findByUserId(Long userId);
+
+    List<UserHistory> findByActionDateTimeBetween(LocalDateTime startAt, LocalDateTime endAt);
+
+    List<UserHistory> findByActionDateTimeBetweenAndUserIdOrderByActionDateTime(LocalDateTime now,
+                                                                                LocalDateTime localDateTime,
+                                                                                Long userId);
+
+    Optional<UserHistory> findByUserIdAndActionDateTime(Long userId, LocalDateTime now);
+
+    List<UserHistory> findByActionDateTimeBefore(LocalDateTime localDateTime);
+}

--- a/src/main/java/com/server/nodak/domain/user/service/UserService.java
+++ b/src/main/java/com/server/nodak/domain/user/service/UserService.java
@@ -2,12 +2,18 @@ package com.server.nodak.domain.user.service;
 
 import com.server.nodak.domain.follow.repository.FollowRepository;
 import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.domain.UserHistory;
 import com.server.nodak.domain.user.dto.CurrentUserInfoResponse;
+import com.server.nodak.domain.user.dto.UserHistoryListResponse;
 import com.server.nodak.domain.user.dto.UserInfoResponse;
 import com.server.nodak.domain.user.dto.UserUpdateDTO;
+import com.server.nodak.domain.user.repository.UserHistoryRepository;
 import com.server.nodak.domain.user.repository.UserRepository;
 import com.server.nodak.exception.common.DataNotFoundException;
 import com.server.nodak.security.SecurityUtils;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +22,9 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private final static int HISTORY_EXPIRATION_DAYS = 30;
     private final UserRepository userRepository;
+    private final UserHistoryRepository userHistoryRepository;
     private final FollowRepository followRepository;
 
     @Transactional(readOnly = true)
@@ -53,5 +61,43 @@ public class UserService {
 
     private User getUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(DataNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserHistoryListResponse> getUserHistory(long userId) {
+        LocalDateTime endAt = LocalDateTime.now();
+        LocalDateTime startAt = endAt.minusDays(HISTORY_EXPIRATION_DAYS - 1);
+
+        List<UserHistory> histories = userHistoryRepository.findByActionDateTimeBetweenAndUserIdOrderByActionDateTime(
+                startAt,
+                endAt, userId);
+
+        List<UserHistoryListResponse> result = new ArrayList<>();
+
+        int historiesIdx = 0;
+
+        if (histories.size() != 0) {
+            for (long i = 0; i < HISTORY_EXPIRATION_DAYS; i++) {
+                if (startAt.plusDays(i).toLocalDate()
+                        .equals(histories.get(historiesIdx).getActionDateTime().toLocalDate())) {
+                    result.add(histories.get(historiesIdx).toListResponse());
+                    historiesIdx++;
+                } else {
+                    result.add(UserHistoryListResponse.builder()
+                            .date(startAt.plusDays(i).toLocalDate())
+                            .level(1L)
+                            .build());
+                }
+            }
+        } else {
+            for (long i = 0; i < HISTORY_EXPIRATION_DAYS; i++) {
+                result.add(UserHistoryListResponse.builder()
+                        .date(startAt.plusDays(i).toLocalDate())
+                        .level(1L)
+                        .build());
+            }
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/server/nodak/domain/user/service/UserService.java
+++ b/src/main/java/com/server/nodak/domain/user/service/UserService.java
@@ -38,8 +38,9 @@ public class UserService {
 
         int followerCount = followRepository.getUserFollowerCount(userId);
         int followeeCount = followRepository.getUserFolloweeCount(userId);
+        List<UserHistoryListResponse> userHistory = getUserHistory(userId);
 
-        return UserInfoResponse.of(user, followerCount, followeeCount);
+        return UserInfoResponse.of(user, followerCount, followeeCount, userHistory);
     }
 
     @Transactional

--- a/src/main/java/com/server/nodak/domain/vote/service/VoteService.java
+++ b/src/main/java/com/server/nodak/domain/vote/service/VoteService.java
@@ -12,6 +12,7 @@ import com.server.nodak.domain.vote.repository.vote.VoteRepository;
 import com.server.nodak.domain.vote.repository.votehistory.VoteHistoryRepository;
 import com.server.nodak.domain.vote.repository.voteoption.VoteOptionRepository;
 import com.server.nodak.exception.common.BadRequestException;
+import com.server.nodak.security.aop.IncreaseUserHistory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ public class VoteService {
     private final PostRepository postRepository;
 
     @Transactional
+    @IncreaseUserHistory(incrementValue = 3)
     public void registerVoteOption(Long userId, Long voteId, Long optionSeq) {
         User user = findUserById(userId);
         Vote vote = findVoteById(voteId);

--- a/src/main/java/com/server/nodak/global/service/SchedulerService.java
+++ b/src/main/java/com/server/nodak/global/service/SchedulerService.java
@@ -1,0 +1,29 @@
+package com.server.nodak.global.service;
+
+import com.server.nodak.domain.user.domain.UserHistory;
+import com.server.nodak.domain.user.repository.UserHistoryRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerService {
+
+    private final UserHistoryRepository userHistoryRepository;
+
+    @Scheduled(cron = "0 5 0 * * *")
+    public void findByUser() {
+        // 오늘 15일
+        LocalDateTime localDateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0)).minusDays(29);
+        List<UserHistory> userHistories = userHistoryRepository.findByActionDateTimeBefore(localDateTime);
+        userHistories.stream().forEach(e -> System.out.println(e.getActionDateTime()));
+        userHistoryRepository.deleteAllById(userHistories.stream().map(e -> e.getId()).toList());
+    }
+}

--- a/src/main/java/com/server/nodak/security/aop/IncreaseUserHistory.java
+++ b/src/main/java/com/server/nodak/security/aop/IncreaseUserHistory.java
@@ -1,0 +1,11 @@
+package com.server.nodak.security.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IncreaseUserHistory {
+}

--- a/src/main/java/com/server/nodak/security/aop/IncreaseUserHistory.java
+++ b/src/main/java/com/server/nodak/security/aop/IncreaseUserHistory.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IncreaseUserHistory {
+    int incrementValue() default 1;
 }

--- a/src/main/java/com/server/nodak/security/aop/UserHistoryAspect.java
+++ b/src/main/java/com/server/nodak/security/aop/UserHistoryAspect.java
@@ -1,0 +1,59 @@
+package com.server.nodak.security.aop;
+
+import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.domain.UserHistory;
+import com.server.nodak.domain.user.repository.UserHistoryRepository;
+import com.server.nodak.domain.user.repository.UserRepository;
+import com.server.nodak.exception.common.DataNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class UserHistoryAspect {
+
+    private final UserRepository userRepository;
+    private final UserHistoryRepository userHistoryRepository;
+
+    @Pointcut("@annotation(com.server.nodak.security.aop.IncreaseUserHistory)")
+    public void increaseHistoryPointCut() {
+    }
+
+    @Around(value = "increaseHistoryPointCut() && args(userId, ..)")
+    public void increaseHistoryExecute(ProceedingJoinPoint joinPoint, Long userId) throws Throwable {
+
+        joinPoint.proceed();
+
+        System.out.println("userId : " + userId);
+        System.out.println("증가");
+
+        // 오늘 날짜에 대한 기록이 없다면
+        LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0));
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new DataNotFoundException());
+
+        Optional<UserHistory> optionalUserHistory = userHistoryRepository.findByUserIdAndActionDateTime(userId,
+                now);
+        if (optionalUserHistory.isEmpty()) {
+            UserHistory userHistory = UserHistory.builder()
+                    .actionDateTime(now)
+                    .count(1L)
+                    .user(user)
+                    .build();
+            userHistoryRepository.save(userHistory);
+        } else {
+            UserHistory userHistory = optionalUserHistory.get();
+            userHistory.increaseCount();
+            userHistoryRepository.save(userHistory);
+        }
+    }
+}

--- a/src/test/java/com/server/nodak/domain/user/repository/UserHistoryRepositoryTest.java
+++ b/src/test/java/com/server/nodak/domain/user/repository/UserHistoryRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.server.nodak.domain.user.repository;
+
+import com.server.nodak.domain.user.domain.User;
+import com.server.nodak.domain.user.domain.UserHistory;
+import com.server.nodak.domain.vote.utils.Utils;
+import com.server.nodak.global.config.QueryDslConfig;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class})
+@DisplayName("UserHistoryRepositoryImpl 테스트")
+@Slf4j
+@Transactional
+class UserHistoryRepositoryTest {
+
+    @Autowired
+    UserHistoryRepository userHistoryRepository;
+
+    @Autowired
+    UserJpaRepository userRepository;
+
+    Random random = new Random();
+
+    User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = Utils.createUser();
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("특정 회원에 대한 날짜 사이의 데이터를 조회합니다.")
+    public void findByActionDateTimeBetweenAndUserIdOrderByActionDateTime() {
+        // given
+        List<UserHistory> userHistories = generateRandomUserHistoryData(20);
+        LocalDateTime startAt = LocalDateTime.of(2024, 6, 5, 0, 0);
+        LocalDateTime endAt = LocalDateTime.of(2024, 6, 15, 23, 59);
+        List<LocalDate> filterLocalDate = userHistories.stream().map(e -> e.getActionDateTime().toLocalDate()).toList()
+                .stream().filter(e -> !e.isBefore(startAt.toLocalDate()) && !e.isAfter(endAt.toLocalDate())).toList();
+        // when
+        List<UserHistory> findUserHistories = userHistoryRepository.findByActionDateTimeBetweenAndUserIdOrderByActionDateTime(
+                startAt, endAt, user.getId());
+        // then
+        Assertions.assertThat(findUserHistories.size()).isEqualTo(filterLocalDate.size());
+    }
+
+
+    public List<UserHistory> generateRandomUserHistoryData(int index) {
+        Set<LocalDate> dates = new HashSet<>();
+
+        List<UserHistory> userHistories = IntStream.rangeClosed(1, index).mapToObj(i -> {
+            LocalDateTime dateTime;
+            LocalDate date;
+            do {
+                dateTime = getRandomDate();
+                date = dateTime.toLocalDate();
+            } while (dates.contains(date));
+            dates.add(date);
+            User findUser = userRepository.findById(user.getId()).get();
+            UserHistory userHistory = UserHistory.builder()
+                    .user(findUser)
+                    .count(random.nextLong(1, 15))
+                    .actionDateTime(dateTime)
+                    .build();
+            return userHistoryRepository.save(userHistory);
+        }).toList();
+
+        return userHistories;
+    }
+
+    private LocalDateTime getRandomDate() {
+        Random random = new Random();
+        int day = random.nextInt(30) + 1;  // 1 to 30
+        int hour = random.nextInt(24);
+        int minute = random.nextInt(60);
+        int second = random.nextInt(60);
+        return LocalDateTime.of(2024, Month.JUNE, day, hour, minute, second);
+    }
+
+}


### PR DESCRIPTION
## Description ✍️
- 사용자 기록 조회 API 구현
-  좋아요 (1) , 게시글 (2) , 댓글 (2) , 투표 (3) 등록 기능에 대한 사용 기록 증가 로직 구현
- 30일 이전 데이터 삭제 스케줄링 구현
- 테스트 코드 작성

![](https://www.notion.so/image/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2F7881e657-8c0b-43bf-8cb0-f084bbfd21d5%2Fd9f77d59-4f6c-4fad-842c-d5f14db4193e%2FUntitled.png?table=block&id=2a140c6f-1588-436b-aca4-2ee5d74788cb&spaceId=7881e657-8c0b-43bf-8cb0-f084bbfd21d5&width=2000&userId=47471456-9b72-4efb-98e4-c4997f3e30e8&cache=v2)

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
