### PR TITLE
refactor : 대댓글 여부에 따라, 댓글 삭제 로직 변경

### DIFF
--- a/src/main/java/com/server/nodak/domain/comment/domain/Comment.java
+++ b/src/main/java/com/server/nodak/domain/comment/domain/Comment.java
@@ -22,8 +22,6 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @Table(name = "comment")
-@SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 public class Comment extends BaseEntity {
 
     @NotBlank
@@ -38,6 +36,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Post post;
 
+    @Setter
     @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
     @ColumnDefault("false")
     private boolean isDeleted;

--- a/src/main/java/com/server/nodak/domain/reply/controller/ReplyController.java
+++ b/src/main/java/com/server/nodak/domain/reply/controller/ReplyController.java
@@ -30,7 +30,7 @@ public class ReplyController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @PatchMapping
+    @DeleteMapping
     @AuthorizationRequired(UserRole.GENERAL)
     public ResponseEntity<ApiResponse<Void>> deleteReply(Principal principal,
                                                                   @RequestBody DeleteReplyRequest deleteRequest) {

--- a/src/main/java/com/server/nodak/domain/reply/repository/ReplyJpaRepository.java
+++ b/src/main/java/com/server/nodak/domain/reply/repository/ReplyJpaRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface ReplyJpaRepository extends JpaRepository<Reply, Long> {
 
     @Query("select r from Reply r where r.comment.id = :commentId")
-    Optional<Reply> findByCommentId(@Param("commentId") Long commentId);
+    List<Reply> findByCommentId(@Param("commentId") Long commentId);
 
     @Query("select r from Reply r where r.user.id = :userId")
     List<Reply> getAllByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/server/nodak/domain/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/server/nodak/domain/reply/repository/ReplyRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface ReplyRepository {
 
-    Optional<Reply> findByCommentId(Long commentId);
+    List<Reply> findByCommentId(Long commentId);
     List<Reply> getAllByUserId(Long userId);
     void save(Reply reply);
     void delete(Reply reply);

--- a/src/main/java/com/server/nodak/domain/reply/repository/ReplyRepositoryImpl.java
+++ b/src/main/java/com/server/nodak/domain/reply/repository/ReplyRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ReplyRepositoryImpl implements ReplyRepository {
     private final ReplyJpaRepository replyJpaRepository;
 
     @Override
-    public Optional<Reply> findByCommentId(Long commentId) {
+    public List<Reply> findByCommentId(Long commentId) {
         return replyJpaRepository.findByCommentId(commentId);
     }
 

--- a/src/test/java/com/server/nodak/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/server/nodak/domain/comment/service/CommentServiceTest.java
@@ -5,9 +5,7 @@ import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.server.nodak.domain.comment.domain.Comment;
 import com.server.nodak.domain.comment.dto.request.CreateCommentRequest;
@@ -18,8 +16,12 @@ import com.server.nodak.domain.comment.repository.CommentRepository;
 import com.server.nodak.domain.post.domain.Category;
 import com.server.nodak.domain.post.domain.Post;
 import com.server.nodak.domain.post.repository.PostRepository;
+import com.server.nodak.domain.reply.entity.Reply;
+import com.server.nodak.domain.reply.repository.ReplyRepository;
 import com.server.nodak.domain.user.domain.User;
 import com.server.nodak.domain.user.repository.UserRepository;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +45,9 @@ class CommentServiceTest {
 
     @Mock
     private CommentJpaRepository commentJpaRepository;
+
+    @Mock
+    private ReplyRepository replyRepository;
 
     @Mock
     private UserRepository userRepository;
@@ -131,15 +136,33 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("댓글 삭제 테스트")
-    void deleteComment_test() {
+    @DisplayName("댓글 삭제 테스트 - 답글이 없는 경우")
+    void deleteComment_noReplies_test() {
         // given
         when(commentJpaRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(replyRepository.findByCommentId(commentId)).thenReturn(Collections.emptyList());
 
         // when
         commentService.deleteComment(postId, userId, commentId);
 
         // then
         verify(commentRepository).delete(comment);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 테스트 - 답글이 있는 경우")
+    void deleteComment_withReplies_test() {
+        // given
+        Reply reply = new Reply(); // 새로운 Reply 객체를 생성합니다.
+        when(commentJpaRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(replyRepository.findByCommentId(commentId)).thenReturn(Arrays.asList(reply));
+
+        // when
+        commentService.deleteComment(postId, userId, commentId);
+
+        // then
+        assertEquals("삭제된 댓글입니다.", comment.getContent());
+        assertTrue(comment.isDeleted());
+        verify(commentRepository, never()).delete(comment);
     }
 }


### PR DESCRIPTION
## Description ✍️
* 댓글 삭제 API
  * PATCH => DELETE 로 변경
 * 하위 댓글이 있는 경우, 원본 댓글을 삭제하면 '삭제된 댓글입니다.' 로 응답
 * 하위 댓글이 없는 경우, 원본 댓글 삭제 시 바로 삭제되도록 변경

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [x] 모든 리뷰어의 승인을 받았나요?